### PR TITLE
Merge from upstream to fix compatibility with upcoming Heroku change

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,8 @@ INSTALL_DIR=$BUILD_DIR/vendor/poppler
 
 ENVSCRIPT=$BUILD_DIR/.profile.d/poppler.sh
 
-POPPLER_DIR=${HOME}/vendor/poppler
+# Single quotes since we want $HOME to be resolved at runtime, not build time.
+POPPLER_DIR='${HOME}/vendor/poppler'
 
 echo "Untarring poppler.tar.gz into ${INSTALL_DIR}"
 


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack has been found to not be compatible with this change.

This PR merges in the fix for this compatibility issue from the upstream repository from which this repo was forked:
https://github.com/survantjames/heroku-buildpack-poppler/pull/2